### PR TITLE
OPENEUROPA-783: Make sure component dependencies are as relaxed as possible.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,42 +6,56 @@ services:
   web:
     image: ${IMAGE_PHP=fpfis/httpd-php-dev:5.6}
     environment:
-     - DOCUMENT_ROOT=/test/oe_profile
+    - DOCUMENT_ROOT=/test/oe_profile
   mysql:
     image: percona/percona-server:5.6
     environment:
-      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+    - MYSQL_ALLOW_EMPTY_PASSWORD=yes
 
 pipeline:
-  composer-install:
+  composer-install-lowest:
     group: prepare
     image: ${IMAGE_PHP=fpfis/httpd-php-dev:5.6}
     volumes:
-      - /cache:/cache
+    - /cache:/cache
     commands:
-      - composer update ${COMPOSER_BOUNDARY}
+    - composer update --prefer-lowest --ansi
+    when:
+      matrix:
+        COMPOSER_BOUNDARY: lowest
+
+  composer-install-highest:
+    group: prepare
+    image: ${IMAGE_PHP=fpfis/httpd-php-dev:5.6}
+    volumes:
+    - /cache:/cache
+    commands:
+    - composer install --ansi
+    when:
+      matrix:
+        COMPOSER_BOUNDARY: highest
 
   site-install:
     image: fpfis/httpd-php-dev:7.1
     commands:
-      - ./vendor/bin/run drupal:site-install
+    - ./vendor/bin/run drupal:site-install
 
   grumphp:
     group: test
     image: ${IMAGE_PHP=fpfis/httpd-php-dev:5.6}
     commands:
-      - ./vendor/bin/grumphp run
+    - ./vendor/bin/grumphp run
 
   behat:
     group: test
     image: ${IMAGE_PHP=fpfis/httpd-php-dev:5.6}
     commands:
-      - ./vendor/bin/behat
+    - ./vendor/bin/behat
 
 matrix:
   IMAGE_PHP:
-    - fpfis/httpd-php-dev:5.6
-    - fpfis/httpd-php-dev:7.1
+  - fpfis/httpd-php-dev:5.6
+  - fpfis/httpd-php-dev:7.1
   COMPOSER_BOUNDARY:
-    - '--prefer-lowest'
-    - ''
+  - lowest
+  - highest

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,7 @@ pipeline:
     volumes:
     - /cache:/cache
     commands:
-    - composer update --prefer-lowest --ansi --no-suggest
+    - composer update --prefer-lowest --ansi --no-suggest --no-progress
     when:
       matrix:
         COMPOSER_BOUNDARY: lowest
@@ -30,7 +30,7 @@ pipeline:
     volumes:
     - /cache:/cache
     commands:
-    - composer install --ansi --no-suggest
+    - composer install --ansi --no-suggest --no-progress
     when:
       matrix:
         COMPOSER_BOUNDARY: highest

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ workspace:
 
 services:
   web:
-    image: fpfis/httpd-php-dev:7.1
+    image: ${IMAGE_PHP=fpfis/httpd-php-dev:5.6}
     environment:
      - DOCUMENT_ROOT=/test/oe_profile
   mysql:
@@ -15,11 +15,11 @@ services:
 pipeline:
   composer-install:
     group: prepare
-    image: fpfis/httpd-php-dev:7.1
+    image: ${IMAGE_PHP=fpfis/httpd-php-dev:5.6}
     volumes:
       - /cache:/cache
     commands:
-      - composer install
+      - composer update ${COMPOSER_BOUNDARY}
 
   site-install:
     image: fpfis/httpd-php-dev:7.1
@@ -28,17 +28,20 @@ pipeline:
 
   grumphp:
     group: test
-    image: fpfis/httpd-php-dev:7.1
+    image: ${IMAGE_PHP=fpfis/httpd-php-dev:5.6}
     commands:
       - ./vendor/bin/grumphp run
 
   behat:
     group: test
-    image: fpfis/httpd-php-dev:7.1
+    image: ${IMAGE_PHP=fpfis/httpd-php-dev:5.6}
     commands:
       - ./vendor/bin/behat
 
 matrix:
+  IMAGE_PHP:
+    - fpfis/httpd-php-dev:5.6
+    - fpfis/httpd-php-dev:7.1
   COMPOSER_BOUNDARY:
-    - lowest
-    - highest
+    - '--prefer-lowest'
+    - ''

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,8 @@ pipeline:
     volumes:
     - /cache:/cache
     commands:
-    - composer update --prefer-lowest --ansi --no-suggest --no-progress
+    - composer install --ansi --no-suggest --no-progress
+    - composer update --prefer-lowest --prefer-stable --ansi --no-suggest --no-progress
     when:
       matrix:
         COMPOSER_BOUNDARY: lowest

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,6 +19,8 @@ pipeline:
     volumes:
     - /cache:/cache
     commands:
+    # @todo remove "composer install" step once the following issue is fixed.
+    # @link https://webgate.ec.europa.eu/CITnet/jira/browse/OPENEUROPA-1234
     - composer install --ansi --no-suggest --no-progress
     - composer update --prefer-lowest --prefer-stable --ansi --no-suggest --no-progress
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,6 +19,7 @@ pipeline:
     volumes:
     - /cache:/cache
     commands:
+    - composer install --ansi --no-suggest --no-progress
     - composer update --prefer-lowest --prefer-stable --ansi --no-suggest --no-progress
     when:
       matrix:

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ workspace:
 
 services:
   web:
-    image: ${IMAGE_PHP=fpfis/httpd-php-dev:5.6}
+    image: fpfis/httpd-php-dev:7.1
     environment:
     - DOCUMENT_ROOT=/test/oe_profile
   mysql:
@@ -15,7 +15,7 @@ services:
 pipeline:
   composer-install-lowest:
     group: prepare
-    image: ${IMAGE_PHP=fpfis/httpd-php-dev:5.6}
+    image: fpfis/httpd-php-dev:7.1
     volumes:
     - /cache:/cache
     commands:
@@ -26,7 +26,7 @@ pipeline:
 
   composer-install-highest:
     group: prepare
-    image: ${IMAGE_PHP=fpfis/httpd-php-dev:5.6}
+    image: fpfis/httpd-php-dev:7.1
     volumes:
     - /cache:/cache
     commands:
@@ -42,20 +42,17 @@ pipeline:
 
   grumphp:
     group: test
-    image: ${IMAGE_PHP=fpfis/httpd-php-dev:5.6}
+    image: fpfis/httpd-php-dev:7.1
     commands:
     - ./vendor/bin/grumphp run
 
   behat:
     group: test
-    image: ${IMAGE_PHP=fpfis/httpd-php-dev:5.6}
+    image: fpfis/httpd-php-dev:7.1
     commands:
     - ./vendor/bin/behat
 
 matrix:
-  IMAGE_PHP:
-  - fpfis/httpd-php-dev:5.6
-  - fpfis/httpd-php-dev:7.1
   COMPOSER_BOUNDARY:
   - lowest
   - highest

--- a/.drone.yml
+++ b/.drone.yml
@@ -37,3 +37,8 @@ pipeline:
     image: fpfis/httpd-php-dev:7.1
     commands:
       - ./vendor/bin/behat
+
+matrix:
+  COMPOSER_BOUNDARY:
+    - lowest
+    - highest

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,7 @@ pipeline:
     volumes:
     - /cache:/cache
     commands:
-    - composer update --prefer-lowest --ansi
+    - composer update --prefer-lowest --ansi --no-suggest
     when:
       matrix:
         COMPOSER_BOUNDARY: lowest
@@ -30,7 +30,7 @@ pipeline:
     volumes:
     - /cache:/cache
     commands:
-    - composer install --ansi
+    - composer install --ansi --no-suggest
     when:
       matrix:
         COMPOSER_BOUNDARY: highest

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,6 @@ pipeline:
     volumes:
     - /cache:/cache
     commands:
-    - composer install --ansi --no-suggest --no-progress
     - composer update --prefer-lowest --prefer-stable --ansi --no-suggest --no-progress
     when:
       matrix:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # OpenEuropa profile
 
 [![Build Status](https://drone.fpfis.eu/api/badges/openeuropa/oe_profile/status.svg?branch=master)](https://drone.fpfis.eu/openeuropa/oe_profile)
+[![Packagist](https://img.shields.io/packagist/v/openeuropa/oe_profile.svg)](https://packagist.org/packages/openeuropa/oe_profile)
 
 Basic installation profile, all it does is:
 

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     },
     "require-dev": {
         "composer/installers": "~1.5",
+        "consolidation/robo": "~1.3.1",
         "cweagans/composer-patches": "~1.6",
         "drupal-composer/drupal-scaffold": "~2.2",
         "drupal/coder": "~8.2.12",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "require-dev": {
         "composer/installers": "~1.5",
-        "consolidation/robo": "~1.2.2",
+        "consolidation/robo": "~1.3.1",
         "drupal-composer/drupal-scaffold": "~2.2",
         "drupal/coder": "~8.2.12",
         "drupal/config_devel": "~1.2",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "drupal/console": "~1.0",
         "drupal/drupal-extension": "~4.0.0@alpha",
         "drush/drush": "~9.0",
-        "nikic/php-parser": "~3.1.5",
+        "nikic/php-parser": "~3.1",
         "openeuropa/code-review": "~1.0.0-alpha4",
         "openeuropa/composer-artifacts": "~0.1",
         "openeuropa/drupal-core-require-dev": "^8.6",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     "require-dev": {
         "composer/installers": "~1.5",
         "consolidation/robo": "~1.3.1",
-        "cweagans/composer-patches": "~1.6",
         "drupal-composer/drupal-scaffold": "~2.2",
         "drupal/coder": "~8.2.12",
         "drupal/config_devel": "~1.2",

--- a/composer.json
+++ b/composer.json
@@ -6,24 +6,22 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "drupal/core": "^8.6",
         "php": "^7.1",
+        "drupal/core": "^8.6",
         "openeuropa/oe_theme": "^0.6.2"
     },
     "require-dev": {
-        "composer/installers": "~1.5",
-        "consolidation/robo": "~1.3.1",
+        "composer/installers": "~1.2",
         "drupal-composer/drupal-scaffold": "~2.2",
-        "drupal/coder": "~8.2.12",
         "drupal/config_devel": "~1.2",
         "drupal/console": "~1.0",
         "drupal/drupal-extension": "~4.0.0@alpha",
         "drush/drush": "~9.0",
-        "nikic/php-parser": "~3.1",
-        "openeuropa/code-review": "~1.0.0-alpha4",
+        "nikic/php-parser": "~3.0",
+        "openeuropa/code-review": "~0.3",
         "openeuropa/composer-artifacts": "~0.1",
-        "openeuropa/drupal-core-require-dev": "^8.6",
-        "openeuropa/task-runner": "~1.0"
+        "openeuropa/drupal-core-require-dev": "~8.6@alpha",
+        "openeuropa/task-runner": "~0.5"
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "openeuropa/code-review": "~1.0",
         "openeuropa/composer-artifacts": "~0.1",
         "openeuropa/drupal-core-require-dev": "^8.6",
-        "openeuropa/task-runner": "~0.8"
+        "openeuropa/task-runner": "~1.0"
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": "^7.1",
         "drupal/core": "~8.6@alpha",
-        "openeuropa/oe_theme": ">=0.2"
+        "openeuropa/oe_theme": "^0.6"
     },
     "require-dev": {
         "composer/installers": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.1",
         "drupal/core": "^8.6",
-        "openeuropa/oe_theme": "^0.6"
+        "php": "^7.1",
+        "openeuropa/oe_theme": "^0.6.2"
     },
     "require-dev": {
         "composer/installers": "~1.5",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "require-dev": {
         "composer/installers": "~1.5",
-        "consolidation/robo": "~1.3.1",
+        "consolidation/robo": "~1.2.2",
         "drupal-composer/drupal-scaffold": "~2.2",
         "drupal/coder": "~8.2.12",
         "drupal/config_devel": "~1.2",

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
         "drupal/drupal-extension": "~4.0.0@alpha",
         "drush/drush": "~9.0",
         "nikic/php-parser": "~3.0",
-        "openeuropa/code-review": "~0.3",
+        "openeuropa/code-review": "~1.0",
         "openeuropa/composer-artifacts": "~0.1",
-        "openeuropa/drupal-core-require-dev": "~8.6@alpha",
-        "openeuropa/task-runner": "~0.5"
+        "openeuropa/drupal-core-require-dev": "^8.6",
+        "openeuropa/task-runner": "~0.8"
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
         "openeuropa/oe_theme": ">=0.2"
     },
     "require-dev": {
-        "composer/installers": "^1.2",
-        "drupal-composer/drupal-scaffold": "^2.2",
+        "composer/installers": "~1.0",
+        "drupal-composer/drupal-scaffold": "~2.0",
         "drupal/config_devel": "~1.2",
-        "drupal/console": "^1",
+        "drupal/console": "~1.0",
         "drupal/drupal-extension": "^4.0.0@alpha",
-        "drush/drush": "^9",
-        "nikic/php-parser": "~3",
+        "drush/drush": "~9.0",
+        "nikic/php-parser": "~3.0",
         "openeuropa/code-review": "~0.3",
         "openeuropa/composer-artifacts": "~0.1",
         "openeuropa/drupal-core-require-dev": "~8.6@alpha",

--- a/composer.json
+++ b/composer.json
@@ -7,21 +7,23 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.1",
-        "drupal/core": "~8.6@alpha",
+        "drupal/core": "^8.6",
         "openeuropa/oe_theme": "^0.6"
     },
     "require-dev": {
-        "composer/installers": "~1.0",
-        "drupal-composer/drupal-scaffold": "~2.0",
+        "composer/installers": "~1.5",
+        "cweagans/composer-patches": "~1.6",
+        "drupal-composer/drupal-scaffold": "~2.2",
+        "drupal/coder": "~8.2.12",
         "drupal/config_devel": "~1.2",
         "drupal/console": "~1.0",
-        "drupal/drupal-extension": "^4.0.0@alpha",
+        "drupal/drupal-extension": "~4.0.0@alpha",
         "drush/drush": "~9.0",
-        "nikic/php-parser": "~3.0",
-        "openeuropa/code-review": "~0.3",
+        "nikic/php-parser": "~3.1.5",
+        "openeuropa/code-review": "~1.0.0-alpha4",
         "openeuropa/composer-artifacts": "~0.1",
-        "openeuropa/drupal-core-require-dev": "~8.6@alpha",
-        "openeuropa/task-runner": "~0.5"
+        "openeuropa/drupal-core-require-dev": "^8.6",
+        "openeuropa/task-runner": "~1.0"
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",


### PR DESCRIPTION
Components dependencies:

  - Update some version to use tilde, so it uses the minimal minor version and also for a consistency use decimal number as the version.

  - Update some packages to use minimal minor version.

  - Added composer boundary to test lowest and highest.

  - Added packagist badge.