### PR TITLE
OPENEUROPA-1609 Fix behat.yml.dist to use drupal-extension properly.

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -8,7 +8,7 @@ default:
         - Drupal\DrupalExtension\Context\DrupalContext
         - Drupal\DrupalExtension\Context\MarkupContext
   extensions:
-    Behat\MinkExtension:
+    Drupal\MinkExtension:
       goutte: ~
       selenium2: ~
       javascript_session: selenium2

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "drupal-composer/drupal-scaffold": "~2.2",
         "drupal/config_devel": "~1.2",
         "drupal/console": "~1.0",
-        "drupal/drupal-extension": "~4.0.0@alpha",
+        "drupal/drupal-extension": "~4.0",
         "drush/drush": "~9.0",
         "nikic/php-parser": "~3.0",
         "openeuropa/code-review": "~1.0",


### PR DESCRIPTION
After moving from drupal-extension v3 to v4 Drupal\MinkExtension has to be used.